### PR TITLE
fix: new file menu option without word new for consistency

### DIFF
--- a/core/src/main/resources/META-INF/zigbrains-core.xml
+++ b/core/src/main/resources/META-INF/zigbrains-core.xml
@@ -189,7 +189,7 @@
         <action
                 id="zigbrains.file.new"
                 class="com.falsepattern.zigbrains.project.actions.ZigNewFileAction"
-                text="New Zig File"
+                text="Zig File"
         >
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
         </action>


### PR DESCRIPTION
The "New File" menu shows labels for various file types without the prefix "New". E.g. "Kotlin Script", "Python File", "Go File". ZigBrains is currently showing "New Zig File". This PR fixes the inconsistency.