### PR TITLE
fix parsing char with backslash

### DIFF
--- a/core/src/main/grammar/Zig.flex
+++ b/core/src/main/grammar/Zig.flex
@@ -56,7 +56,7 @@ dec_int={dec} {dec_}*
 hex_int={hex} {hex_}*
 
 char_char= \\ .
-         | [^\'\r\n\u0085\u2028\u2029]
+         | [^\'\\\r\n\u0085\u2028\u2029]
 
 string_char= \\ .
            | [^\"\r\n\u0085\u2028\u2029]


### PR DESCRIPTION
before:

<img width="350" alt="Screenshot 2025-04-30 at 23 55 18" src="https://github.com/user-attachments/assets/3e02b3ad-dc3b-45c1-a94a-c0d583ed4112" />

after:
<img width="301" alt="Screenshot 2025-04-30 at 23 55 55" src="https://github.com/user-attachments/assets/70ee32ec-8a07-46ed-8795-10bd96ae000c" />
