### PR TITLE
Remove unneeded semicolon in flex file

### DIFF
--- a/core/src/main/grammar/Zig.flex
+++ b/core/src/main/grammar/Zig.flex
@@ -57,7 +57,7 @@ hex_int={hex} {hex_}*
 
 char_escape= "\\x" {hex} {hex}
            | "\\u{" {hex}+ "}"
-           | "\\" [nr\\t\'\"];
+           | "\\" [nr\\t\'\"]
 
 char_char= {char_escape}
          | [^\'\r\n\u0085\u2028\u2029]

--- a/core/src/main/grammar/Zon.flex
+++ b/core/src/main/grammar/Zon.flex
@@ -57,7 +57,7 @@ hex_int={hex} {hex_}*
 
 char_escape= "\\x" {hex} {hex}
            | "\\u{" {hex}+ "}"
-           | "\\" [nr\\t'\"];
+           | "\\" [nr\\t'\"]
 
 char_char= {char_escape}
          | [^\'\r\n\u0085\u2028\u2029]


### PR DESCRIPTION
I noticed that syntax highlighting does not work properly when using the `\"` escape sequence in a string.
After some trial and error, I found an unnecessary semicolon in Zig.flex. Removing it resolved the syntax highlighting issue.

Before
![image](https://github.com/user-attachments/assets/95df5ebf-18fd-4e75-b963-d7059ecd82e5)

After
![image](https://github.com/user-attachments/assets/7e4da09c-aac1-49f1-8a2c-03b4d0c5c65b)
