### PR TITLE
feat: Initial implementation of build scanner

### DIFF
--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ScanBuildActivity.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ScanBuildActivity.kt
@@ -1,0 +1,30 @@
+/*
+ * ZigBrains
+ * Copyright (C) 2023-2025 FalsePattern
+ * All Rights Reserved
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, only version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.falsepattern.zigbrains.project.buildscan
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+class ScanBuildActivity : ProjectActivity {
+	override suspend fun execute(project: Project) {
+		project.zigBuildScan.triggerReload()
+	}
+}

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/Serialization.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/Serialization.kt
@@ -42,7 +42,7 @@ object Serialization {
 		/**
 		 * Contains the index of a project in the projects list
 		 */
-		val dependencies: List<Int>,
+		val dependencies: List<Dependency>,
 	)
 	@Serializable
 	data class Step(
@@ -88,5 +88,16 @@ object Serialization {
 		 * The imported module's idx
 		 */
 		val module: Int,
+	)
+	@Serializable
+	data class Dependency(
+		/**
+		 * The index of the project in the projects list
+ 		 */
+		val project: Int,
+		/**
+		 * Whether the dependency was delcared lazy
+ 		 */
+		val lazy: Boolean,
 	)
 }

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/Serialization.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/Serialization.kt
@@ -1,0 +1,92 @@
+/*
+ * ZigBrains
+ * Copyright (C) 2023-2025 FalsePattern
+ * All Rights Reserved
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, only version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.falsepattern.zigbrains.project.buildscan
+
+import kotlinx.serialization.Serializable
+
+// just a namespace for stuff
+object Serialization {
+	@Serializable
+	data class Project(
+		/**
+		 * The root of the project
+		 */
+		val path: String,
+		/**
+		 * The (top-level) steps the project declares
+		 */
+		val steps: List<Step>,
+		/**
+		 * The modules this project owns, may them be private or public
+		 */
+		val modules: List<Module>,
+		/**
+		 * Contains the index of a project in the projects list
+		 */
+		val dependencies: List<Int>,
+	)
+	@Serializable
+	data class Step(
+		/**
+		 * Self-explanatory
+		 */
+		val name: String,
+		/**
+		 * Description given to the step
+		 */
+		val description: String,
+		/**
+		 * The kind of step, may be any one declared in `std.Build.Step.Id`
+		 */
+		val kind: String,
+	)
+	@Serializable
+	data class Module(
+		/**
+		 * The root `.zig` file
+		 */
+		val root: String,
+		/**
+		 * Public modules are dependable on by other projects
+		 */
+		val public: Boolean,
+		/**
+		 * Imports of this module
+		 */
+		val imports: List<Import>,
+	)
+	@Serializable
+	data class Import(
+		/**
+		 * Name under the import is available in code
+		 */
+		val name: String,
+		/**
+		 * The imported module's owner
+		 */
+		val owner: Int,
+		/**
+		 * The imported module's idx
+		 */
+		val module: Int,
+	)
+}

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScanListener.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScanListener.kt
@@ -31,6 +31,7 @@ interface ZigBuildScanListener {
         MissingToolchain,
         MissingZigExe,
         MissingBuildZig,
-        GeneralError
-    }
+		FailedToCopyHelper,
+		GeneralError
+	}
 }

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScanListener.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScanListener.kt
@@ -1,0 +1,36 @@
+/*
+ * ZigBrains
+ * Copyright (C) 2023-2025 FalsePattern
+ * All Rights Reserved
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, only version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.falsepattern.zigbrains.project.buildscan
+
+interface ZigBuildScanListener {
+    suspend fun preReload() = Unit
+    suspend fun postReload(projects: List<Serialization.Project>) = Unit
+    suspend fun errorReload(type: ErrorType, details: String?) = Unit
+    suspend fun timeoutReload(seconds: Int) = Unit
+
+    enum class ErrorType {
+        MissingToolchain,
+        MissingZigExe,
+        MissingBuildZig,
+        GeneralError
+    }
+}

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScanSyncAction.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScanSyncAction.kt
@@ -1,0 +1,32 @@
+/*
+ * ZigBrains
+ * Copyright (C) 2023-2025 FalsePattern
+ * All Rights Reserved
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, only version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.falsepattern.zigbrains.project.buildscan
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+class ZigBuildScanSyncAction: AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+		project.zigBuildScan.triggerReload()
+    }
+}

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScannerService.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScannerService.kt
@@ -1,0 +1,206 @@
+/*
+ * ZigBrains
+ * Copyright (C) 2023-2025 FalsePattern
+ * All Rights Reserved
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, only version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.falsepattern.zigbrains.project.buildscan
+
+import com.falsepattern.zigbrains.project.buildscan.ZigBuildScanListener.ErrorType
+import com.falsepattern.zigbrains.project.toolchain.ZigToolchainService
+import com.falsepattern.zigbrains.shared.coroutine.withEDTContext
+import com.falsepattern.zigbrains.shared.zigCoroutineScope
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.ui.MessageDialogBuilder
+import com.intellij.openapi.vfs.toNioPathOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import java.net.ServerSocket
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Service(Service.Level.PROJECT)
+class ZigBuildScannerService(private val project: Project) {
+	private val reloading = AtomicBoolean(false)
+	private val reloadScheduled = AtomicBoolean(false)
+	private val reloadMutex = Mutex()
+	private var currentTimeoutSec = DEFAULT_TIMEOUT_SEC
+	private val listeners = ArrayList<ZigBuildScanListener>()
+	private val listenerMutex = Mutex()
+
+	private val projects: MutableList<Serialization.Project> = ArrayList()
+
+	init {
+		this.listeners += object : ZigBuildScanListener {
+			override suspend fun errorReload(type: ErrorType, details: String?) {
+				Notifications.Bus.notify(Notification(
+					GROUP_DISPLAY_ID,
+					"Failed to run build scan",
+					"Output:\n${details}",
+					NotificationType.ERROR
+				))
+			}
+
+			override suspend fun postReload(projects: List<Serialization.Project>) {
+				withEDTContext(ModalityState.defaultModalityState()) {
+					MessageDialogBuilder.okCancel( "notice", "Output:\n${projects}" ).ask( project )
+				}
+			}
+		}
+	}
+
+	suspend fun register(listener: ZigBuildScanListener): Disposable {
+		return listenerMutex.withLock {
+			listeners.add(listener)
+			Disposable {
+				zigCoroutineScope.launch {
+					listenerMutex.withLock {
+						listeners.remove(listener)
+					}
+				}
+			}
+		}
+	}
+
+	@OptIn(ExperimentalSerializationApi::class)
+	suspend fun doReload() {
+		// TODO: Add copying the buildscan helper to project dir
+		preReload()
+		// get the zig toolchain for this project
+		val toolchain = ZigToolchainService.getInstance(project).toolchain ?: run {
+			errorReload(ErrorType.MissingToolchain)
+			return
+		}
+		val zig = toolchain.zig
+
+		// start socket server
+		val server = ServerSocket(0)
+		val thread = Thread {
+			val conn = server.accept()
+			val projects = Json.decodeFromStream<List<Serialization.Project>>(conn.getInputStream())
+			conn.close()
+			// only update if we actually managed to get the data
+			this.projects.clear()
+			this.projects.addAll( projects )
+		}
+		thread.start()
+
+		val result = zig.callWithArgs(
+			project.guessProjectDir()?.toNioPathOrNull(),
+			"build", "--build-file", "builder.zig", "-l",
+			timeoutMillis = currentTimeoutSec * 1000L,
+			ipcProject = project,
+			env = mapOf( "ZIGBRAINS_PORT" to "${server.localPort}" )
+		).getOrElse { throwable ->
+			errorReload(ErrorType.MissingZigExe, throwable.message)
+			null
+		}
+
+		when {
+			result == null -> {}
+			result.checkSuccess(LOG) -> {
+				currentTimeoutSec = DEFAULT_TIMEOUT_SEC
+				postReload()
+			}
+			result.isTimeout -> {
+				timeoutReload(currentTimeoutSec)
+				currentTimeoutSec *= 2
+			}
+			result.stderrLines.any { it.contains("error: no build.zig file found") } -> {
+				errorReload(ErrorType.MissingBuildZig, result.stderr)
+			}
+			else -> errorReload(ErrorType.GeneralError, result.stderr)
+		}
+
+		if (reloadMutex.withLock {
+				if (reloadScheduled.getAndSet(false)) {
+					return@withLock true
+				}
+				reloading.set(false)
+				return@withLock false
+			}) {
+			doReload()
+		}
+	}
+
+	fun triggerReload() {
+		project.zigCoroutineScope.launch {
+			reloadMutex.withLock {
+				if (reloading.getAndSet(true)) {
+					reloadScheduled.set(true)
+					return@launch
+				}
+			}
+			dispatchReload()
+		}
+	}
+
+	private suspend fun dispatchReload() {
+		withEDTContext(ModalityState.defaultModalityState()) {
+			FileDocumentManager.getInstance().saveAllDocuments()
+		}
+		doReload()
+	}
+
+	private suspend fun preReload() {
+		listenerMutex.withLock {
+			listeners.forEach { it.preReload() }
+		}
+	}
+
+	private suspend fun postReload() {
+		listenerMutex.withLock {
+			listeners.forEach { it.postReload(projects) }
+		}
+	}
+
+	private suspend fun errorReload(type: ErrorType, details: String? = null) {
+		listenerMutex.withLock {
+			listeners.forEach { it.errorReload(type, details) }
+		}
+	}
+
+	private suspend fun timeoutReload(seconds: Int) {
+		listenerMutex.withLock {
+			listeners.forEach { it.timeoutReload(seconds) }
+		}
+	}
+
+	companion object {
+		private const val GROUP_DISPLAY_ID = "zigbrains-buildscan"
+	}
+}
+
+val Project.zigBuildScan get() = service<ZigBuildScannerService>()
+
+private const val DEFAULT_TIMEOUT_SEC = 32
+
+private val LOG = Logger.getInstance(ZigBuildScannerService::class.java)

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigScanBuildActivity.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigScanBuildActivity.kt
@@ -23,8 +23,9 @@ package com.falsepattern.zigbrains.project.buildscan
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 
-class ScanBuildActivity : ProjectActivity {
+class ZigScanBuildActivity : ProjectActivity {
 	override suspend fun execute(project: Project) {
-		project.zigBuildScan.triggerReload()
+		// initial loads may use the cached state, as long `build.zig` and `build.zig.zon` didn't change
+		project.zigBuildScan.triggerReload(true)
 	}
 }

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/toolchain/tools/ZigTool.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/toolchain/tools/ZigTool.kt
@@ -34,8 +34,8 @@ import kotlin.io.path.isRegularFile
 abstract class ZigTool(val toolchain: ZigToolchain) {
     abstract val toolName: String
 
-    suspend fun callWithArgs(workingDirectory: Path?, vararg parameters: String, timeoutMillis: Long = Long.MAX_VALUE, ipcProject: Project? = null): Result<ProcessOutput> {
-        val cli = createBaseCommandLine(workingDirectory, *parameters).let { it.getOrElse { return Result.failure(it) } }
+    suspend fun callWithArgs(workingDirectory: Path?, vararg parameters: String, timeoutMillis: Long = Long.MAX_VALUE, ipcProject: Project? = null, env: Map<String, String> = mapOf()): Result<ProcessOutput> {
+        val cli = createBaseCommandLine(workingDirectory, env, *parameters).let { it.getOrElse { return Result.failure(it) } }
         return cli.call(timeoutMillis, ipcProject = ipcProject)
     }
 
@@ -46,10 +46,11 @@ abstract class ZigTool(val toolchain: ZigToolchain) {
 
     private suspend fun createBaseCommandLine(
         workingDirectory: Path?,
-        vararg parameters: String
+		env: Map<String, String>,
+        vararg parameters: String,
     ): Result<GeneralCommandLine> {
         val exe = toolchain.pathToExecutable(toolName)
-        return createCommandLineSafe(workingDirectory, exe, *parameters)
+        return createCommandLineSafe(workingDirectory, exe, *parameters, env = env)
             .mapCatching { toolchain.patchCommandLine(it) }
     }
 }

--- a/core/src/main/kotlin/com/falsepattern/zigbrains/shared/cli/CLIUtil.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/shared/cli/CLIUtil.kt
@@ -116,6 +116,7 @@ fun createCommandLineSafe(
     workingDirectory: Path?,
     exe: Path,
     vararg parameters: String,
+	env: Map<String, String> = mapOf()
 ): Result<GeneralCommandLine> {
     if (!exe.exists())
         return Result.failure(IllegalArgumentException("file does not exist: ${exe.pathString}"))
@@ -126,6 +127,7 @@ fun createCommandLineSafe(
         .withWorkingDirectory(workingDirectory)
         .withParameters(*parameters)
         .withCharset(Charsets.UTF_8)
+		.withEnvironment(env)
     return Result.success(cli)
 }
 

--- a/core/src/main/resources/META-INF/zigbrains-core.xml
+++ b/core/src/main/resources/META-INF/zigbrains-core.xml
@@ -190,7 +190,7 @@
         />
 
         <postStartupActivity
-                implementation="com.falsepattern.zigbrains.project.buildscan.ScanBuildActivity"
+                implementation="com.falsepattern.zigbrains.project.buildscan.ZigScanBuildActivity"
         />
     </extensions>
 

--- a/core/src/main/resources/META-INF/zigbrains-core.xml
+++ b/core/src/main/resources/META-INF/zigbrains-core.xml
@@ -188,6 +188,10 @@
                 contextId="ZIG"
                 implementation="com.falsepattern.zigbrains.zig.codeInsight.ZigContext"
         />
+
+        <postStartupActivity
+                implementation="com.falsepattern.zigbrains.project.buildscan.ScanBuildActivity"
+        />
     </extensions>
 
     <extensions defaultExtensionNs="com.falsepattern.zigbrains">
@@ -219,6 +223,12 @@
                 class="com.falsepattern.zigbrains.project.actions.ZigRunFileAction"
                 icon="AllIcons.RunConfigurations.TestState.Run"
                 use-shortcut-of="RunClass"/>
+        <action
+                id="zigbrains.buildscan.sync"
+                class="com.falsepattern.zigbrains.project.buildscan.ZigBuildScanSyncAction"
+                icon="AllIcons.Actions.Refresh">
+            <add-to-group group-id="ExternalSystem.Actions" anchor="after" relative-to-action="ReloadProjectAction"/>
+        </action>
     </actions>
     <!-- endregion Project -->
 

--- a/core/src/main/resources/fileTemplates/internal/builder.zig
+++ b/core/src/main/resources/fileTemplates/internal/builder.zig
@@ -51,7 +51,7 @@ const Storage = struct {
 	projects: std.ArrayList(Project),
 
 	const Project = struct {
-  		path: []const u8,
+		path: []const u8,
 		steps: []const Serialization.Step,
 		modules: []const Storage.Module,
 		dependencies: []const Dependency,
@@ -69,7 +69,7 @@ const Storage = struct {
 	};
 };
 
-const post_writergate = @hasDecl(std, "Io");
+const postWritergate = @hasDecl( std, "Io" );
 
 pub fn build( b: *std.Build ) !void {
 	// run the project's build.zig
@@ -90,7 +90,7 @@ pub fn build( b: *std.Build ) !void {
 	const port = try std.fmt.parseInt( u16, env.get( "ZIGBRAINS_PORT" ) orelse return error.NoPortGiven, 10 );
 	std.log.info( "[ZigBrains:BuildScan] IDE is listening on port {}", .{ port } );
 
-	// connect to the port
+	// connect to the IDE
 	var stream = try std.net.tcpConnectToAddress(.{ .in = try std.net.Ip4Address.resolveIp( "127.0.0.1", port ) });
 	defer stream.close();
 
@@ -158,11 +158,11 @@ pub fn build( b: *std.Build ) !void {
 	}
 
 	// serialize
-	if (post_writergate) {
-		var writer_buf: [1024]u8 = undefined;
-		var stream_writer = stream.writer(&writer_buf);
-		try std.json.Stringify.value(projects, .{ .whitespace = .indent_4 }, &stream_writer.interface);
-		try stream_writer.interface.flush();
+	if ( postWritergate ) {
+		var writerBuf: [1024]u8 = undefined;
+		var streamWriter = stream.writer( &writerBuf );
+		try std.json.Stringify.value( projects, .{ .whitespace = .indent_4 }, &streamWriter.interface );
+		try streamWriter.interface.flush();
 	} else {
 		try std.json.stringify( projects, .{ .whitespace = .indent_4 }, stream.writer() );
 	}

--- a/core/src/main/resources/fileTemplates/internal/builder.zig
+++ b/core/src/main/resources/fileTemplates/internal/builder.zig
@@ -1,0 +1,250 @@
+const std = @import("std");
+const builder = @import("build.zig");
+const RetType = @typeInfo(@TypeOf(builder.build)).@"fn".return_type.?;
+
+
+// serialization types, must be kept in sync with the ZB counterpart
+const Serialization = struct {
+	const Project = struct {
+		/// The root of the project
+  		path: []const u8,
+		/// The (top-level) steps the project declares
+		steps: []const Step,
+		/// The modules this project owns, may them be private or public
+		modules: []const Module,
+		/// Contains the index of a project in the projects list
+		dependencies: []usize,
+	};
+	const Step = struct {
+		/// Self-explanatory
+		name: []const u8,
+		/// Description given to the step
+		description: []const u8,
+		/// The kind of step, may be any one declared in `std.Build.Step.Id`
+		kind: []const u8,
+	};
+	const Module = struct {
+		/// The root `.zig` file
+		root: []const u8,
+		/// Public modules are dependable on by other projects
+  		public: bool,
+		/// Imports of this module
+  		imports: []const Import,
+	};
+	const Import = struct {
+		/// Name under the import is available in code
+		name: []const u8,
+		/// The imported module's owner
+  		owner: usize,
+		/// The imported module's idx
+  		module: usize,
+	};
+};
+
+const Storage = struct {
+	projects: std.ArrayList(Project),
+
+	const Project = struct {
+  		path: []const u8,
+		steps: []const Serialization.Step,
+		modules: []const Storage.Module,
+		dependencies: []const Dependency,
+	};
+	const Module = struct {
+		module: *std.Build.Module,
+		public: bool,
+		imports: *std.StringArrayHashMapUnmanaged(*std.Build.Module),
+	};
+	const Dependency = struct {
+		name: []const u8,
+		hash: []const u8,
+		path: []const u8,
+	};
+};
+
+
+pub fn build( b: *std.Build ) !void {
+	// run the project's build.zig
+	const res = switch ( @typeInfo(RetType) ) {
+		.error_union => try builder.build( b ),
+		else => builder.build( b )
+	};
+
+	// this scope's lifespan is very short, so we can simply use an arena allocator
+	var arena: std.heap.ArenaAllocator = .init( b.allocator );
+	const alloc = arena.allocator();
+	defer arena.deinit();
+
+	// get hold of the process's env vars
+	var env = try std.process.getEnvMap( b.allocator );
+
+	// get the port the IDE is listening on
+	const port = try std.fmt.parseInt( u16, env.get( "ZIGBRAINS_PORT" ) orelse return error.NoPortGiven, 10 );
+	std.log.info( "[ZigBrains:BuildScan] IDE is listening on port {}", .{ port } );
+
+	// connect to the port
+	var stream = try std.net.tcpConnectToAddress(.{ .in = try std.net.Ip4Address.resolveIp( "127.0.0.1", port ) });
+	defer stream.close();
+
+	// gather data
+	var storage: Storage = .{ .projects = .init( alloc ) };
+	try gatherProjects( b, &storage, alloc );
+
+	const Util = struct {
+		pub fn findProjectIndex( strg: *Storage, needle: []const u8 ) ?usize {
+			for ( strg.projects.items, 0.. ) |proj, idx| {
+				if ( std.mem.eql( u8, needle, proj.path ) ) {
+					return idx;
+				}
+			}
+			return null;
+		}
+		pub fn findProjectModuleIndex( strg: *Storage, projIdx: usize, needle: *std.Build.Module ) ?usize {
+			for ( strg.projects.items[projIdx].modules, 0.. ) |mod, idx| {
+				if ( mod.module == needle ) {
+					return idx;
+				}
+			}
+			return null;
+		}
+	};
+
+	// process everuyhting to be serializable
+	var projects = try alloc.alloc( Serialization.Project, storage.projects.items.len );
+	for ( storage.projects.items, 0.. ) |proj, i| {
+		// post-process the dependencies
+		var dependencies: std.ArrayList(usize) = try .initCapacity( alloc, proj.dependencies.len );
+		for ( proj.dependencies ) |dep| {
+			dependencies.addOneAssumeCapacity().* = Util.findProjectIndex( &storage, dep.path ) orelse continue;
+		}
+		// post-process the modules
+		const modules: []Serialization.Module = try alloc.alloc( Serialization.Module, proj.modules.len );
+		for ( proj.modules, 0.. ) |mud, modIdx| {
+			var imports: std.ArrayList(Serialization.Import) = try .initCapacity( alloc, mud.imports.count() );
+			var iter = mud.imports.iterator();
+			while ( iter.next() ) |imp| {
+				const ownerIdx = Util.findProjectIndex( &storage, imp.value_ptr.*.owner.build_root.path.? ) orelse continue;
+				const moduleIdx = Util.findProjectModuleIndex( &storage, ownerIdx, imp.value_ptr.* ) orelse continue;
+				imports.addOneAssumeCapacity().* = .{
+					.name = imp.key_ptr.*,
+					.owner = ownerIdx,
+					.module = moduleIdx,
+				};
+			}
+
+			modules[modIdx] = .{
+				.root = mud.module.root_source_file.?.getDisplayName(),
+				.public = mud.public,
+				.imports = imports.items
+			};
+		}
+
+		// save the mappings
+		projects[i] = .{
+			.path = proj.path,
+			.steps = proj.steps,
+			.modules = modules,
+			.dependencies = dependencies.items,
+		};
+	}
+
+	// serialize
+	try std.json.stringify( projects, .{ .whitespace = .indent_4 }, stream.writer() );
+
+	// hook is done!
+	return res;
+}
+
+fn gatherProjects( b: *std.Build, storage: *Storage, alloc: std.mem.Allocator ) !void {
+	const root_path = b.build_root.path.?;
+	// ensure we don't traverse a project twice
+	for ( storage.projects.items ) |proj| {
+		if ( std.mem.eql( u8, proj.path, root_path ) ) {
+			return;
+		}
+	}
+
+	// gather steps
+	var steps = try alloc.alloc( Serialization.Step, b.top_level_steps.count() );
+	{
+		var i: usize = 0;
+		var iter = b.top_level_steps.iterator();
+		while ( iter.next() ) |it| {
+			const topLevel = it.value_ptr.*;
+			// usually they have either 0 or 1 dependencies, being the thing that actually runs, in case of 0 its a synthetic step type, usually `uninstall-$x`
+			const deps = topLevel.step.dependencies.items;
+			steps[i] = .{
+				.name = topLevel.step.name,
+				.description = topLevel.description,
+				.kind = if ( deps.len != 0 ) @tagName( deps[0].id ) else "uninstall",
+			};
+			i += 1;
+		}
+	}
+
+	// gather dependencies
+	const deps = try alloc.alloc( Storage.Dependency, b.available_deps.len );
+	{
+		// we do not find the project index here, as that would introduce a dependency on resolving the... dependencies, which can be a problem in case of circular ones
+		for ( b.available_deps, 0.. ) |dep, i| {
+			deps[i] = .{
+				.name = dep.@"0",
+				.path = b.dependency( dep.@"0", .{ } ).builder.build_root.path.?,
+				.hash = dep.@"1"
+			};
+		}
+	}
+
+	// gather modules
+	var modules: std.ArrayList(Storage.Module) = try .initCapacity( alloc, b.modules.count() );
+	{
+		// public modules, we know exactly how many there are, so we prealloc the space for them
+		var modIter = b.modules.iterator();
+		while ( modIter.next() ) |it| {
+			modules.addOneAssumeCapacity().* = .{
+				.module = it.value_ptr.*,
+				.public = true,
+				.imports = &it.value_ptr.*.import_table,
+			};
+		}
+
+		// private modules
+		var iter = b.top_level_steps.iterator();
+		while ( iter.next() ) |it| {
+			try discoverStepModules( &it.value_ptr.*.*.step, &modules );
+		}
+	}
+
+	// save the gathered data
+	(try storage.projects.addOne()).* = .{
+		.path = root_path,
+		.modules = modules.items,
+		.steps = steps,
+		.dependencies = deps,
+	};
+
+	// visit the dependencies
+	for ( b.available_deps ) |dep| {
+		try gatherProjects( b.dependency( dep.@"0", .{ } ).builder, storage, alloc );
+	}
+}
+
+fn discoverStepModules( step: *std.Build.Step, modules: *std.ArrayList(Storage.Module) ) !void {
+	if ( step.id == .compile ) blk: {
+		const compile: *std.Build.Step.Compile = @fieldParentPtr( "step", step );
+		// check if a module was already added
+		for ( modules.items ) |mod| {
+			if ( mod.module == compile.root_module ) {
+				break :blk;
+			}
+		}
+		(try modules.addOne()).* = .{
+			.module = compile.root_module,
+			.public = false,
+			.imports = &compile.root_module.import_table,
+		};
+	}
+	for ( step.dependencies.items ) |s| {
+		try discoverStepModules( s, modules );
+	}
+}

--- a/core/src/main/resources/fileTemplates/internal/builder.zig
+++ b/core/src/main/resources/fileTemplates/internal/builder.zig
@@ -69,6 +69,7 @@ const Storage = struct {
 	};
 };
 
+const post_writergate = @hasDecl(std, "Io");
 
 pub fn build( b: *std.Build ) !void {
 	// run the project's build.zig
@@ -157,7 +158,14 @@ pub fn build( b: *std.Build ) !void {
 	}
 
 	// serialize
-	try std.json.stringify( projects, .{ .whitespace = .indent_4 }, stream.writer() );
+	if (post_writergate) {
+		var writer_buf: [1024]u8 = undefined;
+		var stream_writer = stream.writer(&writer_buf);
+		try std.json.Stringify.value(projects, .{ .whitespace = .indent_4 }, &stream_writer.interface);
+		try stream_writer.interface.flush();
+	} else {
+		try std.json.stringify( projects, .{ .whitespace = .indent_4 }, stream.writer() );
+	}
 
 	// hook is done!
 	return res;

--- a/core/src/main/resources/fileTemplates/internal/gitignore
+++ b/core/src/main/resources/fileTemplates/internal/gitignore
@@ -4,3 +4,4 @@ zig-out/
 build/
 build-*/
 docgen_tmp/
+.zbscanhelper

--- a/core/src/main/resources/zigbrains/ActionsBundle.properties
+++ b/core/src/main/resources/zigbrains/ActionsBundle.properties
@@ -1,3 +1,5 @@
 action.zigbrains.discover.steps.text=Reload Zig Build Steps
 action.zigbrains.discover.steps.description=Scan the project and detect build.zig steps using the current toolchain
 action.zigbrains.file.new.text=Zig File
+action.zigbrains.buildscan.sync.text=Reload zig build
+action.zigbrains.buildscan.sync.description=Syncs the IDE's knowledge of the project with Zig's build system


### PR DESCRIPTION
Currently, it can load the project dependencies, steps, modules and relative imports.
It doesn't yet support lazy dependencies, we currently ignore them as they're hard to "load", as they require a re-evaluation of the buildscript.