### PR TITLE
feat: `zls-bad-config` in-editor banner rework

### DIFF
--- a/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScannerService.kt
+++ b/core/src/main/kotlin/com/falsepattern/zigbrains/project/buildscan/ZigBuildScannerService.kt
@@ -26,9 +26,6 @@ import com.falsepattern.zigbrains.project.toolchain.ZigToolchainService
 import com.falsepattern.zigbrains.shared.coroutine.withEDTContext
 import com.falsepattern.zigbrains.shared.zigCoroutineScope
 import com.intellij.ide.trustedProjects.TrustedProjects
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.writeAction

--- a/lsp/src/main/kotlin/com/falsepattern/zigbrains/lsp/action/OpenZigToolchainConfigurableAction.kt
+++ b/lsp/src/main/kotlin/com/falsepattern/zigbrains/lsp/action/OpenZigToolchainConfigurableAction.kt
@@ -1,0 +1,33 @@
+/*
+ * ZigBrains
+ * Copyright (C) 2023-2025 FalsePattern
+ * All Rights Reserved
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, only version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.falsepattern.zigbrains.lsp.action
+
+import com.falsepattern.zigbrains.project.settings.ZigConfigurable
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
+
+class OpenZigToolchainConfigurableAction: AnAction() {
+	override fun actionPerformed(e: AnActionEvent) {
+		ShowSettingsUtil.getInstance().showSettingsDialog( e.project!!, ZigConfigurable::class.java )
+	}
+}

--- a/lsp/src/main/kotlin/com/falsepattern/zigbrains/lsp/notification/ZigEditorNotificationProvider.kt
+++ b/lsp/src/main/kotlin/com/falsepattern/zigbrains/lsp/notification/ZigEditorNotificationProvider.kt
@@ -72,8 +72,7 @@ class ZigEditorNotificationProvider: EditorNotificationProvider, DumbAware {
             } else {
                 status = EditorNotificationPanel.Status.Warning
                 text = ZLSBundle.message("notification.banner.zls-not-running")
-//				actionLabel = ZLSBundle.message("notification.banner.zls-bad-config")
-//				actionId =
+				// TODO: Does this need the same "open-action" treatment?
             }
             val panel = EditorNotificationPanel(editor, status)
 			panel.text = text

--- a/lsp/src/main/kotlin/com/falsepattern/zigbrains/lsp/notification/ZigEditorNotificationProvider.kt
+++ b/lsp/src/main/kotlin/com/falsepattern/zigbrains/lsp/notification/ZigEditorNotificationProvider.kt
@@ -57,19 +57,31 @@ class ZigEditorNotificationProvider: EditorNotificationProvider, DumbAware {
         }
         return Function { editor ->
             val status: EditorNotificationPanel.Status
-            val message: String
+            val text: String
+            var actionLabel: String? = null
+            var actionId: String? = null
             val result = runBlocking { task.await() }
             if (result == null)
                 return@Function null
 
             if (!result) {
                 status = EditorNotificationPanel.Status.Error
-                message = ZLSBundle.message("notification.banner.zls-bad-config")
+                text = ZLSBundle.message("notification.banner.zls-bad-config")
+                actionLabel = ZLSBundle.message("notification.banner.zls-bad-config.action")
+                actionId = "zigbrains.open.configurable.toolchain"
             } else {
                 status = EditorNotificationPanel.Status.Warning
-                message = ZLSBundle.message("notification.banner.zls-not-running")
+                text = ZLSBundle.message("notification.banner.zls-not-running")
+//				actionLabel = ZLSBundle.message("notification.banner.zls-bad-config")
+//				actionId =
             }
-            EditorNotificationPanel(editor, status).also { it.text = message }
+            val panel = EditorNotificationPanel(editor, status)
+			panel.text = text
+			if (actionId != null && actionLabel != null) {
+				panel.createActionLabel(actionLabel, actionId)
+			}
+
+			return@Function panel
         }
     }
 }

--- a/lsp/src/main/resources/META-INF/zigbrains-lsp.xml
+++ b/lsp/src/main/resources/META-INF/zigbrains-lsp.xml
@@ -101,4 +101,12 @@
                 topic="com.falsepattern.zigbrains.lsp.LanguageServerStarter"
         />
     </projectListeners>
+
+    <actions resource-bundle="zigbrains.lsp.ActionsBundle">
+        <!--suppress PluginXmlCapitalization -->
+        <action
+                id="zigbrains.open.configurable.toolchain"
+                class="com.falsepattern.zigbrains.lsp.action.OpenZigToolchainConfigurableAction"
+                icon="com.falsepattern.zigbrains.Icons.Zig"/>
+    </actions>
 </idea-plugin>

--- a/lsp/src/main/resources/zigbrains/lsp/ActionsBundle.properties
+++ b/lsp/src/main/resources/zigbrains/lsp/ActionsBundle.properties
@@ -1,0 +1,1 @@
+action.zigbrains.open.configurable.toolchain.text=Open Zig toolchain configuration

--- a/lsp/src/main/resources/zigbrains/lsp/Bundle.properties
+++ b/lsp/src/main/resources/zigbrains/lsp/Bundle.properties
@@ -57,7 +57,8 @@ notification.message.zls-config-not-file.content=ZLS config file is not a regula
 notification.message.zls-config-path-invalid.content=ZLS config path could not be parted: {0}
 notification.message.zls-config-autogen-failed.content=Failed to autogenerate ZLS config from toolchain
 notification.banner.zls-not-running=Zig Language Server is not running. Check the [Language Servers] tool menu!
-notification.banner.zls-bad-config=Zig Language Server is misconfigured. Check [Settings | Languages \\& Frameworks | Zig]!
+notification.banner.zls-bad-config=Zig Language Server is misconfigured.
+notification.banner.zls-bad-config.action=Setup Zig Toolchain
 progress.title.create-connection-provider=Creating ZLS connection provider
 # suppress inspection "UnusedProperty"
 lsp.zls.name=Zig Language Server


### PR DESCRIPTION
Now it has a action connected to it, like when you don't have a JDK selected, to open the relevant settings to be configured.